### PR TITLE
Bump to Dotnet 10 and latest version of StandAlone WireMock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,51 @@
+*.swp
+*.*~
+project.lock.json
+.DS_Store
+*.pyc
+nupkg/
+
+# Visual Studio Code
+.vscode/*
+!.vscode/settings.json
+
+# Rider
+.idea/
+
+# Visual Studio
+.vs/
+
+# Fleet
+.fleet/
+
+# Code Rush
+.cr/
+
+# User-specific files
+*.suo
+*.user
+*.userosscache
+*.sln.docstates
+
+# Build results
+[Dd]ebug/
+[Dd]ebugPublic/
+[Rr]elease/
+[Rr]eleases/
+x64/
+x86/
+build/
+bld/
+[Bb]in/
+[Oo]bj/
+[Oo]ut/
+msbuild.log
+msbuild.err
+msbuild.wrn
+
+# Node.js build artifacts
+node_modules/
+package-lock.json
+package.json
+
+.vscode/settings.json

--- a/WireMockTemplate/WireMockTemplate.csproj
+++ b/WireMockTemplate/WireMockTemplate.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net10.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="WireMock.Net.StandAlone" Version="1.5.51" />
+      <PackageReference Include="WireMock.Net.StandAlone" Version="2.5.0" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This pull request updates the project to use .NET 10.0 and upgrades the WireMock.Net.StandAlone package to a newer version.

Dependency and framework upgrades:

* Updated the target framework in `WireMockTemplate.csproj` from `net8.0` to `net10.0` to use the latest .NET version.
* Upgraded the `WireMock.Net.StandAlone` NuGet package from version `1.5.51` to `2.5.0` in `WireMockTemplate.csproj`.